### PR TITLE
Fix mcl

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true,
+  "deno.autoFmtOnSave": true,
+  "deno.suggest.imports.hosts": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
+  "editor.rulers": [80],
   "deno.enable": true,
   "deno.lint": true,
   "deno.unstable": true,
-  "deno.autoFmtOnSave": true,
-  "deno.suggest.imports.hosts": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/server/src/lib/hubble-bls/src/hashToField.ts
+++ b/server/src/lib/hubble-bls/src/hashToField.ts
@@ -1,98 +1,101 @@
-import { BigNumber } from "ethers";
-import { sha256, arrayify, zeroPad } from "ethers/lib/utils";
-import { BadDomain } from "./exceptions";
+import { BigNumber } from "../../sky/ethers/bignumber.ts";
+import { arrayify, zeroPad } from "../../sky/ethers/bytes.ts";
+import { sha256 } from "../../sky/ethers/sha2.ts";
+
+import { BadDomain } from "./exceptions.ts";
 
 export const FIELD_ORDER = BigNumber.from(
-    "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+  "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
 );
 
 export function hashToField(
-    domain: Uint8Array,
-    msg: Uint8Array,
-    count: number
+  domain: Uint8Array,
+  msg: Uint8Array,
+  count: number,
 ): BigNumber[] {
-    const u = 48;
-    const _msg = expandMsg(domain, msg, count * u);
-    const els = [];
-    for (let i = 0; i < count; i++) {
-        const el = BigNumber.from(_msg.slice(i * u, (i + 1) * u)).mod(
-            FIELD_ORDER
-        );
-        els.push(el);
-    }
-    return els;
+  const u = 48;
+  const _msg = expandMsg(domain, msg, count * u);
+  const els = [];
+  for (let i = 0; i < count; i++) {
+    const el = BigNumber.from(_msg.slice(i * u, (i + 1) * u)).mod(
+      FIELD_ORDER,
+    );
+    els.push(el);
+  }
+  return els;
 }
 
 export function expandMsg(
-    domain: Uint8Array,
-    msg: Uint8Array,
-    outLen: number
+  domain: Uint8Array,
+  msg: Uint8Array,
+  outLen: number,
 ): Uint8Array {
-    if (domain.length > 32)
-        throw new BadDomain(`Expect 32 bytes but got ${domain.length}`);
+  if (domain.length > 32) {
+    throw new BadDomain(`Expect 32 bytes but got ${domain.length}`);
+  }
 
-    const out: Uint8Array = new Uint8Array(outLen);
+  const out: Uint8Array = new Uint8Array(outLen);
 
-    const len0 = 64 + msg.length + 2 + 1 + domain.length + 1;
-    const in0: Uint8Array = new Uint8Array(len0);
-    // zero pad
-    let off = 64;
-    // msg
-    in0.set(msg, off);
-    off += msg.length;
-    // l_i_b_str
-    in0.set([(outLen >> 8) & 0xff, outLen & 0xff], off);
-    off += 2;
-    // I2OSP(0, 1)
-    in0.set([0], off);
-    off += 1;
-    // DST_prime
-    in0.set(domain, off);
-    off += domain.length;
-    in0.set([domain.length], off);
+  const len0 = 64 + msg.length + 2 + 1 + domain.length + 1;
+  const in0: Uint8Array = new Uint8Array(len0);
+  // zero pad
+  let off = 64;
+  // msg
+  in0.set(msg, off);
+  off += msg.length;
+  // l_i_b_str
+  in0.set([(outLen >> 8) & 0xff, outLen & 0xff], off);
+  off += 2;
+  // I2OSP(0, 1)
+  in0.set([0], off);
+  off += 1;
+  // DST_prime
+  in0.set(domain, off);
+  off += domain.length;
+  in0.set([domain.length], off);
 
-    const b0 = sha256(in0);
+  const b0 = sha256(in0);
 
-    const len1 = 32 + 1 + domain.length + 1;
-    const in1: Uint8Array = new Uint8Array(len1);
-    // b0
-    in1.set(arrayify(b0), 0);
-    off = 32;
-    // I2OSP(1, 1)
-    in1.set([1], off);
-    off += 1;
-    // DST_prime
-    in1.set(domain, off);
-    off += domain.length;
-    in1.set([domain.length], off);
+  const len1 = 32 + 1 + domain.length + 1;
+  const in1: Uint8Array = new Uint8Array(len1);
+  // b0
+  in1.set(arrayify(b0), 0);
+  off = 32;
+  // I2OSP(1, 1)
+  in1.set([1], off);
+  off += 1;
+  // DST_prime
+  in1.set(domain, off);
+  off += domain.length;
+  in1.set([domain.length], off);
 
-    const b1 = sha256(in1);
+  const b1 = sha256(in1);
 
-    // b_i = H(strxor(b_0, b_(i - 1)) || I2OSP(i, 1) || DST_prime);
-    const ell = Math.floor((outLen + 32 - 1) / 32);
-    let bi = b1;
+  // b_i = H(strxor(b_0, b_(i - 1)) || I2OSP(i, 1) || DST_prime);
+  const ell = Math.floor((outLen + 32 - 1) / 32);
+  let bi = b1;
 
-    for (let i = 1; i < ell; i++) {
-        const ini: Uint8Array = new Uint8Array(32 + 1 + domain.length + 1);
-        const nb0 = zeroPad(arrayify(b0), 32);
-        const nbi = zeroPad(arrayify(bi), 32);
-        const tmp = new Uint8Array(32);
-        for (let i = 0; i < 32; i++) {
-            tmp[i] = nb0[i] ^ nbi[i];
-        }
-
-        ini.set(tmp, 0);
-        let off = 32;
-        ini.set([1 + i], off);
-        off += 1;
-        ini.set(domain, off);
-        off += domain.length;
-        ini.set([domain.length], off);
-
-        out.set(arrayify(bi), 32 * (i - 1));
-        bi = sha256(ini);
+  for (let i = 1; i < ell; i++) {
+    const ini: Uint8Array = new Uint8Array(32 + 1 + domain.length + 1);
+    const nb0 = zeroPad(arrayify(b0), 32);
+    const nbi = zeroPad(arrayify(bi), 32);
+    const tmp = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      tmp[i] = nb0[i] ^ nbi[i];
     }
 
-    out.set(arrayify(bi), 32 * (ell - 1));
-    return out;
+    ini.set(tmp, 0);
+    let off = 32;
+    ini.set([1 + i], off);
+    off += 1;
+    ini.set(domain, off);
+    off += domain.length;
+    ini.set([domain.length], off);
+
+    out.set(arrayify(bi), 32 * (i - 1));
+    bi = sha256(ini);
+  }
+
+  out.set(arrayify(bi), 32 * (ell - 1));
+  return out;
 }

--- a/server/src/lib/hubble-bls/src/mcl.ts
+++ b/server/src/lib/hubble-bls/src/mcl.ts
@@ -1,24 +1,31 @@
-const mcl = require("mcl-wasm");
-import { BigNumber } from "ethers";
-import { hashToField } from "./hashToField";
-import { arrayify, hexlify, randomBytes, isHexString } from "ethers/lib/utils";
+import mcl from "../../sky/mcl-wasm.ts";
+
+import { BigNumber } from "../../sky/ethers/bignumber.ts";
+import { hashToField } from "./hashToField.ts";
+import { arrayify, hexlify, isHexString } from "../../sky/ethers/bytes.ts";
+import { randomBytes } from "../../sky/ethers/random.ts";
+
 import {
-    BadDomain,
-    BadHex,
-    BadMessage,
-    EmptyArray,
-    MismatchLength,
-    BadByteLength,
-} from "./exceptions";
+  BadByteLength,
+  BadDomain,
+  BadHex,
+  BadMessage,
+  EmptyArray,
+  MismatchLength,
+} from "./exceptions.ts";
 
 export const FIELD_ORDER = BigNumber.from(
-    "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+  "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
 );
 
-export type mclG2 = any;
-export type mclG1 = any;
-export type mclFP = any;
-export type mclFR = any;
+// deno-lint-ignore no-explicit-any
+type ExplicitAny = any;
+
+export type mclG2 = ExplicitAny;
+export type mclG1 = ExplicitAny;
+export type mclFP = ExplicitAny;
+export type mclFR = ExplicitAny;
+
 export type SecretKey = mclFR;
 export type MessagePoint = mclG1;
 export type Signature = mclG1;
@@ -28,247 +35,252 @@ export type solG1 = [string, string];
 export type solG2 = [string, string, string, string];
 
 export interface keyPair {
-    pubkey: PublicKey;
-    secret: SecretKey;
+  pubkey: PublicKey;
+  secret: SecretKey;
 }
 
 export type Domain = Uint8Array;
 
 export async function init() {
-    await mcl.init(mcl.BN_SNARK1);
-    mcl.setMapToMode(mcl.BN254);
+  await mcl.init(mcl.BN_SNARK1);
+  mcl.setMapToMode(mcl.BN254);
 }
 
 export function validateDomain(domain: Domain) {
-    if (domain.length != 32)
-        throw new BadDomain(`Expect 32 bytes but got ${domain.length}`);
+  if (domain.length != 32) {
+    throw new BadDomain(`Expect 32 bytes but got ${domain.length}`);
+  }
 }
 
 export function hashToPoint(msg: string, domain: Domain): MessagePoint {
-    if (!isHexString(msg))
-        throw new BadMessage(`Expect hex string but got ${msg}`);
+  if (!isHexString(msg)) {
+    throw new BadMessage(`Expect hex string but got ${msg}`);
+  }
 
-    const _msg = arrayify(msg);
-    const [e0, e1] = hashToField(domain, _msg, 2);
-    const p0 = mapToPoint(e0);
-    const p1 = mapToPoint(e1);
-    const p = mcl.add(p0, p1);
-    p.normalize();
-    return p;
+  const _msg = arrayify(msg);
+  const [e0, e1] = hashToField(domain, _msg, 2);
+  const p0 = mapToPoint(e0);
+  const p1 = mapToPoint(e1);
+  const p = mcl.add(p0, p1);
+  p.normalize();
+  return p;
 }
 
 export function mapToPoint(e0: BigNumber): mclG1 {
-    let e1 = new mcl.Fp();
-    e1.setStr(e0.mod(FIELD_ORDER).toString());
-    return e1.mapToG1();
+  const e1 = new mcl.Fp();
+  e1.setStr(e0.mod(FIELD_ORDER).toString());
+  return e1.mapToG1();
 }
 
 export function toBigEndian(p: mclFP): Uint8Array {
-    // serialize() gets a little-endian output of Uint8Array
-    // reverse() turns it into big-endian, which Solidity likes
-    return p.serialize().reverse();
+  // serialize() gets a little-endian output of Uint8Array
+  // reverse() turns it into big-endian, which Solidity likes
+  return p.serialize().reverse();
 }
 
 export function g1(): mclG1 {
-    const g1 = new mcl.G1();
-    g1.setStr("1 0x01 0x02", 16);
-    return g1;
+  const g1 = new mcl.G1();
+  g1.setStr("1 0x01 0x02", 16);
+  return g1;
 }
 
 export function g2(): mclG2 {
-    const g2 = new mcl.G2();
-    g2.setStr(
-        "1 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa 0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b"
-    );
-    return g2;
+  const g2 = new mcl.G2();
+  g2.setStr(
+    "1 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa 0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
+  );
+  return g2;
 }
 
 export function negativeG2(): mclG2 {
-    const g2 = new mcl.G2();
-    g2.setStr(
-        "1 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec"
-    );
-    return g2;
+  const g2 = new mcl.G2();
+  g2.setStr(
+    "1 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec",
+  );
+  return g2;
 }
 
 export function g1ToHex(p: mclG1): solG1 {
-    p.normalize();
-    const x = hexlify(toBigEndian(p.getX()));
-    const y = hexlify(toBigEndian(p.getY()));
-    return [x, y];
+  p.normalize();
+  const x = hexlify(toBigEndian(p.getX()));
+  const y = hexlify(toBigEndian(p.getY()));
+  return [x, y];
 }
 
 export function g2ToHex(p: mclG2): solG2 {
-    p.normalize();
-    const x = toBigEndian(p.getX());
-    const x0 = hexlify(x.slice(32));
-    const x1 = hexlify(x.slice(0, 32));
-    const y = toBigEndian(p.getY());
-    const y0 = hexlify(y.slice(32));
-    const y1 = hexlify(y.slice(0, 32));
-    return [x0, x1, y0, y1];
+  p.normalize();
+  const x = toBigEndian(p.getX());
+  const x0 = hexlify(x.slice(32));
+  const x1 = hexlify(x.slice(0, 32));
+  const y = toBigEndian(p.getY());
+  const y0 = hexlify(y.slice(32));
+  const y1 = hexlify(y.slice(0, 32));
+  return [x0, x1, y0, y1];
 }
 
 export function getPubkey(secret: SecretKey): PublicKey {
-    const pubkey = mcl.mul(g2(), secret);
-    pubkey.normalize();
-    return pubkey;
+  const pubkey = mcl.mul(g2(), secret);
+  pubkey.normalize();
+  return pubkey;
 }
 
 export function newKeyPair(): keyPair {
-    const secret = randFr();
-    const pubkey = getPubkey(secret);
-    return { pubkey, secret };
+  const secret = randFr();
+  const pubkey = getPubkey(secret);
+  return { pubkey, secret };
 }
 
 export function sign(
-    message: string,
-    secret: SecretKey,
-    domain: Domain
+  message: string,
+  secret: SecretKey,
+  domain: Domain,
 ): { signature: Signature; messagePoint: MessagePoint } {
-    const messagePoint = hashToPoint(message, domain);
-    const signature = mcl.mul(messagePoint, secret);
-    signature.normalize();
-    return { signature, messagePoint };
+  const messagePoint = hashToPoint(message, domain);
+  const signature = mcl.mul(messagePoint, secret);
+  signature.normalize();
+  return { signature, messagePoint };
 }
 
 export function verifyRaw(
-    signature: Signature,
-    pubkey: PublicKey,
-    message: MessagePoint
+  signature: Signature,
+  pubkey: PublicKey,
+  message: MessagePoint,
 ): boolean {
-    const negG2 = new mcl.PrecomputedG2(negativeG2());
+  const negG2 = new mcl.PrecomputedG2(negativeG2());
 
-    const pairings = mcl.precomputedMillerLoop2mixed(
-        message,
-        pubkey,
-        signature,
-        negG2
-    );
-    return mcl.finalExp(pairings).isOne();
+  const pairings = mcl.precomputedMillerLoop2mixed(
+    message,
+    pubkey,
+    signature,
+    negG2,
+  );
+  return mcl.finalExp(pairings).isOne();
 }
 
 export function verifyMultipleRaw(
-    aggSignature: Signature,
-    pubkeys: PublicKey[],
-    messages: MessagePoint[]
+  aggSignature: Signature,
+  pubkeys: PublicKey[],
+  messages: MessagePoint[],
 ): boolean {
-    const size = pubkeys.length;
-    if (size === 0) throw new EmptyArray("number of public key is zero");
-    if (size != messages.length)
-        throw new MismatchLength(
-            `public keys ${size}; messages ${messages.length}`
-        );
-    const negG2 = new mcl.PrecomputedG2(negativeG2());
-    let accumulator = mcl.precomputedMillerLoop(aggSignature, negG2);
-    for (let i = 0; i < size; i++) {
-        accumulator = mcl.mul(
-            accumulator,
-            mcl.millerLoop(messages[i], pubkeys[i])
-        );
-    }
-    return mcl.finalExp(accumulator).isOne();
+  const size = pubkeys.length;
+  if (size === 0) throw new EmptyArray("number of public key is zero");
+  if (size != messages.length) {
+    throw new MismatchLength(
+      `public keys ${size}; messages ${messages.length}`,
+    );
+  }
+  const negG2 = new mcl.PrecomputedG2(negativeG2());
+  let accumulator = mcl.precomputedMillerLoop(aggSignature, negG2);
+  for (let i = 0; i < size; i++) {
+    accumulator = mcl.mul(
+      accumulator,
+      mcl.millerLoop(messages[i], pubkeys[i]),
+    );
+  }
+  return mcl.finalExp(accumulator).isOne();
 }
 
 export function aggregateRaw(signatures: Signature[]): Signature {
-    let aggregated = new mcl.G1();
-    for (const sig of signatures) {
-        aggregated = mcl.add(aggregated, sig);
-    }
-    aggregated.normalize();
-    return aggregated;
+  let aggregated = new mcl.G1();
+  for (const sig of signatures) {
+    aggregated = mcl.add(aggregated, sig);
+  }
+  aggregated.normalize();
+  return aggregated;
 }
 
 export function randFr(): mclFR {
-    const r = hexlify(randomBytes(12));
-    let fr = new mcl.Fr();
-    fr.setHashOf(r);
-    return fr;
+  const r = hexlify(randomBytes(12));
+  const fr = new mcl.Fr();
+  fr.setHashOf(r);
+  return fr;
 }
 
 export function randMclG1(): mclG1 {
-    const p = mcl.mul(g1(), randFr());
-    p.normalize();
-    return p;
+  const p = mcl.mul(g1(), randFr());
+  p.normalize();
+  return p;
 }
 
 export function randMclG2(): mclG2 {
-    const p = mcl.mul(g2(), randFr());
-    p.normalize();
-    return p;
+  const p = mcl.mul(g2(), randFr());
+  p.normalize();
+  return p;
 }
 
 export function randG1(): solG1 {
-    return g1ToHex(randMclG1());
+  return g1ToHex(randMclG1());
 }
 
 export function randG2(): solG2 {
-    return g2ToHex(randMclG2());
+  return g2ToHex(randMclG2());
 }
 
 export function parseFr(hex: string) {
-    if (!isHexString(hex)) throw new BadHex(`Expect hex but got ${hex}`);
-    const fr = new mcl.Fr();
-    fr.setHashOf(hex);
-    return fr;
+  if (!isHexString(hex)) throw new BadHex(`Expect hex but got ${hex}`);
+  const fr = new mcl.Fr();
+  fr.setHashOf(hex);
+  return fr;
 }
 
 export function parseG1(solG1: solG1): mclG1 {
-    const g1 = new mcl.G1();
-    const [x, y] = solG1;
-    g1.setStr(`1 ${x} ${y}`, 16);
-    return g1;
+  const g1 = new mcl.G1();
+  const [x, y] = solG1;
+  g1.setStr(`1 ${x} ${y}`, 16);
+  return g1;
 }
 
 export function parseG2(solG2: solG2): mclG2 {
-    const g2 = new mcl.G2();
-    const [x0, x1, y0, y1] = solG2;
-    g2.setStr(`1 ${x0} ${x1} ${y0} ${y1}`);
-    return g2;
+  const g2 = new mcl.G2();
+  const [x0, x1, y0, y1] = solG2;
+  g2.setStr(`1 ${x0} ${x1} ${y0} ${y1}`);
+  return g2;
 }
 
 export function dumpFr(fr: mclFR): string {
-    return `0x${fr.serializeToHexStr()}`;
+  return `0x${fr.serializeToHexStr()}`;
 }
 
 export function loadFr(hex: string): mclFR {
-    const fr = new mcl.Fr();
-    fr.deserializeHexStr(hex.slice(2));
-    return fr;
+  const fr = new mcl.Fr();
+  fr.deserializeHexStr(hex.slice(2));
+  return fr;
 }
 
 export function dumpG1(solG1: solG1): string {
-    const [x, y] = solG1;
-    return `0x${x.slice(2)}${y.slice(2)}`;
+  const [x, y] = solG1;
+  return `0x${x.slice(2)}${y.slice(2)}`;
 }
 
 export function dumpG2(solG2: solG2): string {
-    const [x0, x1, y0, y1] = solG2;
-    return `0x${x0.slice(2)}${x1.slice(2)}${y0.slice(2)}${y1.slice(2)}`;
+  const [x0, x1, y0, y1] = solG2;
+  return `0x${x0.slice(2)}${x1.slice(2)}${y0.slice(2)}${y1.slice(2)}`;
 }
 
 export function loadG1(hex: string): solG1 {
-    const bytesarray = arrayify(hex);
-    if (bytesarray.length != 64)
-        throw new BadByteLength(
-            `Expect length 64 but got ${bytesarray.length}`
-        );
-    const x = hexlify(bytesarray.slice(0, 32));
-    const y = hexlify(bytesarray.slice(32));
-    return [x, y];
+  const bytesarray = arrayify(hex);
+  if (bytesarray.length != 64) {
+    throw new BadByteLength(
+      `Expect length 64 but got ${bytesarray.length}`,
+    );
+  }
+  const x = hexlify(bytesarray.slice(0, 32));
+  const y = hexlify(bytesarray.slice(32));
+  return [x, y];
 }
 
 export function loadG2(hex: string): solG2 {
-    const bytesarray = arrayify(hex);
-    if (bytesarray.length != 128)
-        throw new BadByteLength(
-            `Expect length 128 but got ${bytesarray.length}`
-        );
-    const x0 = hexlify(bytesarray.slice(0, 32));
-    const x1 = hexlify(bytesarray.slice(32, 64));
-    const y0 = hexlify(bytesarray.slice(64, 96));
-    const y1 = hexlify(bytesarray.slice(96, 128));
-    return [x0, x1, y0, y1];
+  const bytesarray = arrayify(hex);
+  if (bytesarray.length != 128) {
+    throw new BadByteLength(
+      `Expect length 128 but got ${bytesarray.length}`,
+    );
+  }
+  const x0 = hexlify(bytesarray.slice(0, 32));
+  const x1 = hexlify(bytesarray.slice(32, 64));
+  const y0 = hexlify(bytesarray.slice(64, 96));
+  const y1 = hexlify(bytesarray.slice(96, 128));
+  return [x0, x1, y0, y1];
 }
 
 export const getMclInstance = () => mcl;

--- a/server/src/lib/hubble-bls/src/signer.ts
+++ b/server/src/lib/hubble-bls/src/signer.ts
@@ -1,109 +1,109 @@
-import { NullSigner } from "./exceptions";
+import { NullSigner } from "./exceptions.ts";
 import {
-    solG2,
-    Domain,
-    getPubkey,
-    g2ToHex,
-    sign,
-    g1ToHex,
-    aggregateRaw,
-    solG1,
-    SecretKey,
-    randFr,
-    PublicKey,
-    parseG1,
-    parseG2,
-    verifyRaw,
-    verifyMultipleRaw,
-    hashToPoint,
-    init,
-    parseFr,
-} from "./mcl";
+  aggregateRaw,
+  Domain,
+  g1ToHex,
+  g2ToHex,
+  getPubkey,
+  hashToPoint,
+  init,
+  parseFr,
+  parseG1,
+  parseG2,
+  PublicKey,
+  randFr,
+  SecretKey,
+  sign,
+  solG1,
+  solG2,
+  verifyMultipleRaw,
+  verifyRaw,
+} from "./mcl.ts";
 
 export interface BlsSignerInterface {
-    pubkey: solG2;
-    sign(message: string): solG1;
-    verify(signature: solG1, pubkey: solG2, message: string): boolean;
-    verifyMultiple(
-        aggSignature: solG1,
-        pubkeys: solG2[],
-        messages: string[]
-    ): boolean;
+  pubkey: solG2;
+  sign(message: string): solG1;
+  verify(signature: solG1, pubkey: solG2, message: string): boolean;
+  verifyMultiple(
+    aggSignature: solG1,
+    pubkeys: solG2[],
+    messages: string[],
+  ): boolean;
 }
 
 // Useful when your real signer is not loaded but need a placeholder
 export class NullBlsSinger implements BlsSignerInterface {
-    get pubkey(): solG2 {
-        throw new NullSigner("NullSinger has no public key");
-    }
-    sign(message: string): solG1 {
-        throw new NullSigner("NullSinger dosen't sign");
-    }
-    verify(signature: solG1, pubkey: solG2, message: string): boolean {
-        throw new NullSigner("NullSinger dosen't verify");
-    }
-    verifyMultiple(
-        aggSignature: solG1,
-        pubkeys: solG2[],
-        messages: string[]
-    ): boolean {
-        throw new NullSigner("NullSinger dosen't verify");
-    }
+  get pubkey(): solG2 {
+    throw new NullSigner("NullSinger has no public key");
+  }
+  sign(_message: string): solG1 {
+    throw new NullSigner("NullSinger dosen't sign");
+  }
+  verify(_signature: solG1, _pubkey: solG2, _message: string): boolean {
+    throw new NullSigner("NullSinger dosen't verify");
+  }
+  verifyMultiple(
+    _aggSignature: solG1,
+    _pubkeys: solG2[],
+    _messages: string[],
+  ): boolean {
+    throw new NullSigner("NullSinger dosen't verify");
+  }
 }
 
 export const nullBlsSigner = new NullBlsSinger();
 
 export class BlsVerifier {
-    constructor(public domain: Domain) {}
-    public verify(signature: solG1, pubkey: solG2, message: string) {
-        const signatureG1 = parseG1(signature);
-        const pubkeyG2 = parseG2(pubkey);
-        const messagePoint = hashToPoint(message, this.domain);
-        return verifyRaw(signatureG1, pubkeyG2, messagePoint);
-    }
-    public verifyMultiple(
-        aggSignature: solG1,
-        pubkeys: solG2[],
-        messages: string[]
-    ) {
-        const signatureG1 = parseG1(aggSignature);
-        const pubkeyG2s = pubkeys.map(parseG2);
-        const messagePoints = messages.map((m) => hashToPoint(m, this.domain));
-        return verifyMultipleRaw(signatureG1, pubkeyG2s, messagePoints);
-    }
+  constructor(public domain: Domain) {}
+  public verify(signature: solG1, pubkey: solG2, message: string) {
+    const signatureG1 = parseG1(signature);
+    const pubkeyG2 = parseG2(pubkey);
+    const messagePoint = hashToPoint(message, this.domain);
+    return verifyRaw(signatureG1, pubkeyG2, messagePoint);
+  }
+  public verifyMultiple(
+    aggSignature: solG1,
+    pubkeys: solG2[],
+    messages: string[],
+  ) {
+    const signatureG1 = parseG1(aggSignature);
+    const pubkeyG2s = pubkeys.map(parseG2);
+    const messagePoints = messages.map((m) => hashToPoint(m, this.domain));
+    return verifyMultipleRaw(signatureG1, pubkeyG2s, messagePoints);
+  }
 }
 
 export class BlsSignerFactory {
-    static async new() {
-        await init();
-        return new BlsSignerFactory();
-    }
-    private constructor() {}
+  static async new() {
+    await init();
+    return new BlsSignerFactory();
+  }
+  private constructor() {}
 
-    public getSigner(domain: Domain, secretHex?: string) {
-        const secret = secretHex ? parseFr(secretHex) : randFr();
-        return new BlsSigner(domain, secret);
-    }
+  public getSigner(domain: Domain, secretHex?: string) {
+    const secret = secretHex ? parseFr(secretHex) : randFr();
+    return new BlsSigner(domain, secret);
+  }
 }
 
 class BlsSigner extends BlsVerifier implements BlsSignerInterface {
-    private _pubkey: PublicKey;
-    constructor(public domain: Domain, private secret: SecretKey) {
-        super(domain);
-        this._pubkey = getPubkey(secret);
-    }
-    get pubkey(): solG2 {
-        return g2ToHex(this._pubkey);
-    }
+  private _pubkey: PublicKey;
+  constructor(public domain: Domain, private secret: SecretKey) {
+    super(domain);
+    this._pubkey = getPubkey(secret);
+  }
+  get pubkey(): solG2 {
+    return g2ToHex(this._pubkey);
+  }
 
-    public sign(message: string): solG1 {
-        const { signature } = sign(message, this.secret, this.domain);
-        return g1ToHex(signature);
-    }
+  public sign(message: string): solG1 {
+    const { signature } = sign(message, this.secret, this.domain);
+    return g1ToHex(signature);
+  }
 }
 
 export function aggregate(signatures: solG1[]): solG1 {
-    const signatureG1s = signatures.map((s) => parseG1(s));
-    const aggregated = aggregateRaw(signatureG1s);
-    return g1ToHex(aggregated);
+  const signatureG1s = signatures.map((s) => parseG1(s));
+  const aggregated = aggregateRaw(signatureG1s);
+  return g1ToHex(aggregated);
 }

--- a/server/src/lib/hubble-bls/test/hashToField.test.ts
+++ b/server/src/lib/hubble-bls/test/hashToField.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts";
+
+import * as mcl from "../src/mcl.ts";
+
+import { expandMsg } from "../src/hashToField.ts";
+import { hexlify } from "../../sky/ethers/bytes.ts";
+
+const DOMAIN_STR = "QUUX-V01-CS02-with-expander";
+const DST = new TextEncoder().encode(DOMAIN_STR);
+
+interface vector {
+  msg: string;
+  outLen: number;
+  expected: string;
+}
+
+const vectors: vector[] = [
+  // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-09#appendix-I
+  {
+    msg: "",
+    outLen: 32,
+    expected:
+      "0xf659819a6473c1835b25ea59e3d38914c98b374f0970b7e4c92181df928fca88",
+  },
+  {
+    msg: "abc",
+    outLen: 32,
+    expected:
+      "0x1c38f7c211ef233367b2420d04798fa4698080a8901021a795a1151775fe4da7",
+  },
+  {
+    msg: "abcdef0123456789",
+    outLen: 32,
+    expected:
+      "0x8f7e7b66791f0da0dbb5ec7c22ec637f79758c0a48170bfb7c4611bd304ece89",
+  },
+  {
+    msg:
+      "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+    outLen: 32,
+    expected:
+      "0x72d5aa5ec810370d1f0013c0df2f1d65699494ee2a39f72e1716b1b964e1c642",
+  },
+  {
+    msg:
+      "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    outLen: 32,
+    expected:
+      "0x3b8e704fc48336aca4c2a12195b720882f2162a4b7b13a9c350db46f429b771b",
+  },
+  {
+    msg: "",
+    outLen: 128,
+    expected:
+      "0x8bcffd1a3cae24cf9cd7ab85628fd111bb17e3739d3b53f89580d217aa79526f1708354a76a402d3569d6a9d19ef3de4d0b991e4f54b9f20dcde9b95a66824cbdf6c1a963a1913d43fd7ac443a02fc5d9d8d77e2071b86ab114a9f34150954a7531da568a1ea8c760861c0cde2005afc2c114042ee7b5848f5303f0611cf297f",
+  },
+  {
+    msg: "abc",
+    outLen: 128,
+    expected:
+      "0xfe994ec51bdaa821598047b3121c149b364b178606d5e72bfbb713933acc29c186f316baecf7ea22212f2496ef3f785a27e84a40d8b299cec56032763eceeff4c61bd1fe65ed81decafff4a31d0198619c0aa0c6c51fca15520789925e813dcfd318b542f8799441271f4db9ee3b8092a7a2e8d5b75b73e28fb1ab6b4573c192",
+  },
+  {
+    msg: "abcdef0123456789",
+    outLen: 128,
+    expected:
+      "0xc9ec7941811b1e19ce98e21db28d22259354d4d0643e301175e2f474e030d32694e9dd5520dde93f3600d8edad94e5c364903088a7228cc9eff685d7eaac50d5a5a8229d083b51de4ccc3733917f4b9535a819b445814890b7029b5de805bf62b33a4dc7e24acdf2c924e9fe50d55a6b832c8c84c7f82474b34e48c6d43867be",
+  },
+  {
+    msg:
+      "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+    outLen: 128,
+    expected:
+      "0x48e256ddba722053ba462b2b93351fc966026e6d6db493189798181c5f3feea377b5a6f1d8368d7453faef715f9aecb078cd402cbd548c0e179c4ed1e4c7e5b048e0a39d31817b5b24f50db58bb3720fe96ba53db947842120a068816ac05c159bb5266c63658b4f000cbf87b1209a225def8ef1dca917bcda79a1e42acd8069",
+  },
+  {
+    msg:
+      "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    outLen: 128,
+    expected:
+      "0x396962db47f749ec3b5042ce2452b619607f27fd3939ece2746a7614fb83a1d097f554df3927b084e55de92c7871430d6b95c2a13896d8a33bc48587b1f66d21b128a1a8240d5b0c26dfe795a1a842a0807bb148b77c2ef82ed4b6c9f7fcb732e7f94466c8b51e52bf378fba044a31f5cb44583a892f5969dcd73b3fa128816e",
+  },
+];
+
+Deno.test("Hash to Field - expand message", async () => {
+  await mcl.init();
+  for (let i = 0; i < vectors.length; i++) {
+    const v = vectors[i];
+    const msg = new TextEncoder().encode(v.msg);
+    const outLen = v.outLen;
+    const out = expandMsg(DST, msg, outLen);
+    assertEquals(hexlify(out), v.expected);
+  }
+});
+
+Deno.test("Hash to Field - hash to point", async () => {
+  await mcl.init();
+  const expectedX =
+    "0x09b6a2dec1f1b0747c73332e5147ecacde20767f28a9b68261713bed9a1d2432";
+  const expectedY =
+    "0x0cb70ff0b1bdb5d30006bd0cc03dc2c071dcff0daea886c9793f304c695c1bc6";
+  const dst = new TextEncoder().encode("xxx");
+  const msg = "0x616263";
+  const p = mcl.hashToPoint(msg, dst);
+  const [x, y] = mcl.g1ToHex(p);
+  assertEquals(x, expectedX);
+  assertEquals(y, expectedY);
+});

--- a/server/src/lib/hubble-bls/test/mcl.test.ts
+++ b/server/src/lib/hubble-bls/test/mcl.test.ts
@@ -1,0 +1,80 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.93.0/testing/asserts.ts";
+
+import { arrayify } from "../../sky/ethers/bytes.ts";
+import { keccak256 } from "../../sky/ethers/keccak256.ts";
+import { formatBytes32String } from "../../sky/ethers/strings.ts";
+
+import * as mcl from "../src/mcl.ts";
+
+// This is the raw API, it is not recommended to use it directly in your application
+
+const DOMAIN = arrayify(keccak256("0x1234ABCD"));
+
+Deno.test("BLS raw API - parse g1", async function () {
+  await mcl.init();
+  const mclG1 = mcl.randMclG1();
+  assert(mcl.parseG1(mcl.g1ToHex(mclG1)).isEqual(mclG1));
+});
+
+Deno.test("BLS raw API - parse g2", async function () {
+  await mcl.init();
+  const mclG2 = mcl.randMclG2();
+  assert(mcl.parseG2(mcl.g2ToHex(mclG2)).isEqual(mclG2));
+});
+
+Deno.test("BLS raw API - load and dumps Fr", async function () {
+  await mcl.init();
+  const fr = mcl.randFr();
+  assert(fr.isEqual(mcl.loadFr(mcl.dumpFr(fr))));
+});
+
+Deno.test("BLS raw API - load and dumps G1", async function () {
+  await mcl.init();
+  const solG1 = mcl.g1ToHex(mcl.randMclG1());
+  assertEquals(mcl.loadG1(mcl.dumpG1(solG1)).join(", "), solG1.join(", "));
+});
+
+Deno.test("BLS raw API - load and dumps G2", async function () {
+  await mcl.init();
+  const solG2 = mcl.g2ToHex(mcl.randMclG2());
+  assertEquals(mcl.loadG2(mcl.dumpG2(solG2)).join(", "), solG2.join(", "));
+});
+
+Deno.test("BLS raw API - verify single signature", async function () {
+  await mcl.init();
+  // mcl.sign takes hex string as input, so the raw string needs to be encoded
+  const message = formatBytes32String("Hello");
+  const { pubkey, secret } = mcl.newKeyPair();
+  const { signature, messagePoint } = mcl.sign(message, secret, DOMAIN);
+
+  // Note that we use the message produced by mcl.sign
+  assert(mcl.verifyRaw(signature, pubkey, messagePoint));
+
+  const { pubkey: badPubkey } = mcl.newKeyPair();
+  assert(!mcl.verifyRaw(signature, badPubkey, messagePoint));
+});
+
+Deno.test("BLS raw API - verify aggregated signature", async function () {
+  await mcl.init();
+  const rawMessages = ["Hello", "how", "are", "you"];
+  const messages: mcl.MessagePoint[] = [];
+  const pubkeys: mcl.PublicKey[] = [];
+  const signatures: mcl.Signature[] = [];
+  for (const raw of rawMessages) {
+    const message = formatBytes32String(raw);
+    const { pubkey, secret } = mcl.newKeyPair();
+    const { signature, messagePoint } = mcl.sign(
+      message,
+      secret,
+      DOMAIN,
+    );
+    messages.push(messagePoint);
+    pubkeys.push(pubkey);
+    signatures.push(signature);
+  }
+  const aggSignature = mcl.aggregateRaw(signatures);
+  assert(mcl.verifyMultipleRaw(aggSignature, pubkeys, messages));
+});

--- a/server/src/lib/hubble-bls/test/signer.test.ts
+++ b/server/src/lib/hubble-bls/test/signer.test.ts
@@ -1,0 +1,47 @@
+import { assert } from "https://deno.land/std@0.93.0/testing/asserts.ts";
+
+import { arrayify } from "https://cdn.skypack.dev/@ethersproject/bytes@v5.1.0?dts";
+import { keccak256 } from "https://cdn.skypack.dev/@ethersproject/keccak256@v5.1.0?dts";
+import { formatBytes32String } from "https://cdn.skypack.dev/@ethersproject/strings@v5.1.0?dts";
+
+import { aggregate, BlsSignerFactory } from "../src/signer.ts";
+
+// Domain is a data that signer and verifier must agree on
+// A verifier considers a signature invalid if it is signed with a different domain
+const DOMAIN = arrayify(keccak256("0x1234ABCD"));
+
+Deno.test("BLS Signer - verify single signature", async () => { // message should be a hex string
+  const message = formatBytes32String("Hello");
+
+  const factory = await BlsSignerFactory.new();
+
+  // A signer can be instantiate with new key pair generated
+  const signer = factory.getSigner(DOMAIN);
+  // ... or with an existing secret
+  const signer2 = factory.getSigner(DOMAIN, "0xabcd");
+
+  const signature = signer.sign(message);
+
+  assert(signer.verify(signature, signer.pubkey, message));
+  assert(!signer.verify(signature, signer2.pubkey, message));
+});
+
+Deno.test("BLS Signer - verify aggregated signature", async () => {
+  const factory = await BlsSignerFactory.new();
+  const rawMessages = ["Hello", "how", "are", "you"];
+  const signers = [];
+  const messages = [];
+  const pubkeys = [];
+  const signatures = [];
+  for (const raw of rawMessages) {
+    const message = formatBytes32String(raw);
+    const signer = factory.getSigner(DOMAIN);
+    const signature = signer.sign(message);
+    signers.push(signer);
+    messages.push(message);
+    pubkeys.push(signer.pubkey);
+    signatures.push(signature);
+  }
+  const aggSignature = aggregate(signatures);
+  assert(signers[0].verifyMultiple(aggSignature, pubkeys, messages));
+});

--- a/server/src/lib/hubble-bls/test/signer.test.ts
+++ b/server/src/lib/hubble-bls/test/signer.test.ts
@@ -1,8 +1,8 @@
 import { assert } from "https://deno.land/std@0.93.0/testing/asserts.ts";
 
-import { arrayify } from "https://cdn.skypack.dev/@ethersproject/bytes@v5.1.0?dts";
-import { keccak256 } from "https://cdn.skypack.dev/@ethersproject/keccak256@v5.1.0?dts";
-import { formatBytes32String } from "https://cdn.skypack.dev/@ethersproject/strings@v5.1.0?dts";
+import { arrayify } from "../../sky/ethers/bytes.ts";
+import { keccak256 } from "../../sky/ethers/keccak256.ts";
+import { formatBytes32String } from "../../sky/ethers/strings.ts";
 
 import { aggregate, BlsSignerFactory } from "../src/signer.ts";
 

--- a/server/src/lib/sky/ethers/bignumber.ts
+++ b/server/src/lib/sky/ethers/bignumber.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/bignumber@v5.1.0?dts";

--- a/server/src/lib/sky/ethers/bytes.ts
+++ b/server/src/lib/sky/ethers/bytes.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/bytes@v5.1.0?dts";

--- a/server/src/lib/sky/ethers/keccak256.ts
+++ b/server/src/lib/sky/ethers/keccak256.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/keccak256@v5.1.0?dts";

--- a/server/src/lib/sky/ethers/random.ts
+++ b/server/src/lib/sky/ethers/random.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/random@v5.1.0?dts";

--- a/server/src/lib/sky/ethers/sha2.ts
+++ b/server/src/lib/sky/ethers/sha2.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/sha2@v5.1.0?dts";

--- a/server/src/lib/sky/ethers/strings.ts
+++ b/server/src/lib/sky/ethers/strings.ts
@@ -1,0 +1,1 @@
+export * from "https://cdn.skypack.dev/@ethersproject/strings@v5.1.0?dts";

--- a/server/src/lib/sky/mcl-wasm.ts
+++ b/server/src/lib/sky/mcl-wasm.ts
@@ -1,0 +1,4 @@
+import mcl from "https://cdn.skypack.dev/mcl-wasm?dts";
+
+// deno-lint-ignore no-explicit-any
+export default mcl as any;


### PR DESCRIPTION
Skypack did the trick here (had to do some detective work to get the @ethersproject/(package)-specific imports). I actually ended up creating lib/sky/ethers/* to mimic ethers' package structure. Probably most of ethers is usable in deno this way.

Other than that this is on-save autofixes from deno and adding `.ts` to the end of imports and such. Also porting over the tests from [thehubbleproject/hubble-bls](https://github.com/thehubbleproject/hubble-bls) to verify.

```
➜  bls-wallet git:(fix-mcl) deno test
running 11 tests
test Hash to Field - expand message ... ok (151ms)
test Hash to Field - hash to point ... ok (94ms)
test BLS raw API - parse g1 ... ok (93ms)
test BLS raw API - parse g2 ... ok (94ms)
test BLS raw API - load and dumps Fr ... ok (93ms)
test BLS raw API - load and dumps G1 ... ok (93ms)
test BLS raw API - load and dumps G2 ... ok (93ms)
test BLS raw API - verify single signature ... ok (104ms)
test BLS raw API - verify aggregated signature ... ok (105ms)
test BLS Signer - verify single signature ... ok (104ms)
test BLS Signer - verify aggregated signature ... ok (110ms)

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (1134ms)
```